### PR TITLE
Update GitHub spelling

### DIFF
--- a/about.html
+++ b/about.html
@@ -32,7 +32,7 @@
       <li class="spacer-push"></li>
       <li class="mobile-hide"><a href="/news">News</a></li>
       <li class="mobile-hide"><a href="/about">About</a></li>
-      <li class="mobile-hide"><a href="https://github.com/onnx">Github </a></li>
+      <li class="mobile-hide"><a href="https://github.com/onnx">GitHub </a></li>
       <li class="spacer"></li>
       <li class="mobile-show"><a id="mobile-nav-open"><i class="menu-icon"></i></a></li>
     </ul>
@@ -78,7 +78,7 @@
           <p>
             Operators are implemented externally to the graph, but the set of built-in operators are portable across frameworks. Every framework supporting ONNX will provide implementations of these operators on the applicable data types.
           </p>
-          <p>More details can be found on the <a href="https://github.com/onnx/onnx">Github site</a></p>
+          <p>More details can be found on the <a href="https://github.com/onnx/onnx">GitHub site</a></p>
         </div>
       </div>
     </div>
@@ -162,7 +162,7 @@
     <div class="side-menu">
         <div><a href="/about">About</a></div>
         <div><a href="/news">News</a></div>
-        <div><a href="https://github.com/onnx/onnx">Github</a></div>
+        <div><a href="https://github.com/onnx/onnx">GitHub</a></div>
     </div>
   </div>
 
@@ -187,5 +187,3 @@
   </script>
 </body>
 </html>
-
-

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
       <li class="spacer-push"></li>
       <li class="mobile-hide"><a href="/news">News</a></li>
       <li class="mobile-hide"><a href="/about">About</a></li>
-      <li class="mobile-hide"><a href="https://github.com/onnx">Github </a></li>
+      <li class="mobile-hide"><a href="https://github.com/onnx">GitHub </a></li>
       <li class="spacer"></li>
       <li class="mobile-show"><a id="mobile-nav-open"><i class="menu-icon"></i></a></li>
     </ul>
@@ -103,7 +103,7 @@
 
   <div class="fp-section-wide">
     <div class="fp-section">
-      <h2>Github</h2>
+      <h2>GitHub</h2>
       <div class="fp-section">
         <div class="left text-content">
 			<p>ONNX is a community project. We encourage others to adopt ONNX and support it in their tools. We invite others to join the effort and contribute feedback, ideas, and code. Start experimenting today.</p>
@@ -194,7 +194,7 @@
     <div class="side-menu">
         <div><a href="/about">About</a></div>
         <div><a href="/news">News</a></div>
-        <div><a href="https://github.com/onnx/onnx">Github</a></div>
+        <div><a href="https://github.com/onnx/onnx">GitHub</a></div>
     </div>
   </div>
 

--- a/news.html
+++ b/news.html
@@ -32,7 +32,7 @@
       <li class="spacer-push"></li>
       <li class="mobile-hide"><a href="/news">News</a></li>
       <li class="mobile-hide"><a href="/about">About</a></li>
-      <li class="mobile-hide"><a href="https://github.com/onnx">Github </a></li>
+      <li class="mobile-hide"><a href="https://github.com/onnx">GitHub </a></li>
       <li class="spacer"></li>
       <li class="mobile-show"><a id="mobile-nav-open"><i class="menu-icon"></i></a></li>
     </ul>
@@ -228,7 +228,7 @@
     <div class="side-menu">
         <div><a href="/about">About</a></div>
         <div><a href="/news">News</a></div>
-        <div><a href="https://github.com/onnx/onnx">Github</a></div>
+        <div><a href="https://github.com/onnx/onnx">GitHub</a></div>
     </div>
   </div>
 
@@ -253,4 +253,3 @@
   </script>
 </body>
 </html>
-


### PR DESCRIPTION
Fixes a teeny typo with the <kbd>H</kbd> in GitHub 😉 

<img width="1183" alt="screen_shot_2017-10-10_at_10_32_51_am" src="https://user-images.githubusercontent.com/121322/31401096-9c023788-ada6-11e7-8597-deec540b6609.png">
