### PR TITLE
Updated Getting started

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -74,12 +74,11 @@
                     <h2>Caffe2</h2>
                     <div class="framework-instructions">
                         <strong>Installing</strong>
-                        <p>Caffe2 bindings live in the <a href="https://github.com/onnx/onnx-caffe2">
-                            https://github.com/onnx/onnx-caffe2</a> repo.</p>
+                        <p>Caffe2 now supports the importing and exporting of ONNX models natively.</p>
                         <ul style="margin: 6px;">
                             <li style="list-style-type: disc; padding: 0 0 1em;">
-                                It can be installed as a separate package:
-                                <code>pip install onnx-caffe2</code>.</li>
+                                Caffe2 with ONNX support can be installed using:
+                                <code>pip install caffe2</code>.</li>
                         </ul>
                         <strong>Exporting ONNX Models</strong>
                         <p>To export models, you can follow the tutorial at


### PR DESCRIPTION
Installation and tutorials now reflect that ONNX is natively supported in Caffe2.