### PR TITLE
Updated Caffe2 Install link

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -77,8 +77,9 @@
                         <p>Caffe2 now supports the importing and exporting of ONNX models natively.</p>
                         <ul style="margin: 6px;">
                             <li style="list-style-type: disc; padding: 0 0 1em;">
-                                Caffe2 with ONNX support can be installed using:
-                                <code>pip install caffe2</code>.</li>
+                                You can learn more about how to install Caffe2 with ONNX support here:
+                                <a href="https://caffe2.ai/docs/getting-started.html">https://github.com/onnx/tutorials/blob/master/tutorials/Caffe2OnnxExport.ipynb</a>.
+                                         
                         </ul>
                         <strong>Exporting ONNX Models</strong>
                         <p>To export models, you can follow the tutorial at


### PR DESCRIPTION
Removed pip install to make it more generic pointing ppl to the caffe getting started page.