### PR TITLE
Added custom 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,63 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+
+  <title>Oops!</title>
+  <meta name="description" content="The new open ecosystem for interchangeable AI models">
+  <meta name="author" content="[author]">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <meta property="og:title" content="ONNX: Open Neural Network Exchange Format">
+  <meta property="og:type" content="website">
+  <meta property="og:description" name="description" content="The new open ecosystem for interchangeable AI models">
+  <meta property="og:image" content="assets/thumb.jpg">
+
+  <link href="https://fonts.googleapis.com/css?family=Dosis" rel="stylesheet">
+  <link rel="stylesheet" href="css/normalize.css?v=7.0">
+  <!--<link rel="stylesheet" href="css/main.css?v=2.1">-->
+  <!-- <link rel="stylesheet" href="css/main.css?v=1.0"> -->
+  <link rel="stylesheet" href="css/main.css">
+  <link rel="stylesheet" href="css/news-feed.css">
+  <link rel="stylesheet" href="css/font.css?v=1.0">
+  <link rel="icon" type="image/png" href="assets/mlogo.png">
+  <!--[if lt IE 9]>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js"></script>
+  <![endif]-->
+
+  <script src="https://use.fontawesome.com/e23d6c4fc6.js"></script>
+  <script src="https://www.w3schools.com/lib/w3.js"></script>
+  <script src="js/jquery-3.2.1.min.js"></script>
+  <script src="js/news-feed.js"></script>
+</head>
+
+<body>
+    <div w3-include-html="partials/nav.html"></div>
+
+    <header role="banner" class="fp-header">
+        <a class="brand">Oops!</a>
+        <div class="oneliner">You've reached a dead end.</div>
+        <div class="oneliner">If you feel like something should be here, you can
+        <a target="_blank" href="https://github.com/onnx/onnx.github.io/issues/new">open an issue</a>
+        on GitHub.</div>
+        <div class="oneliner">Click <a href="https://onnx.ai/">here</a> to go back to the main page.</div>
+        <div class="overlay">
+        </div>
+        <div class="covervid-wrapper">
+            <video id="covervid" autoplay loop muted preload="auto">
+                <source src="assets/video.webm" type="video/webm" />
+                <source src="assets/video.mp4" type="video/mp4" />
+                <source src="assets/video.ogv" type="video/ogg" />
+            </video>
+        </div>
+    </header>
+
+    <script src="js/prism.js" async defer></script>
+    <div w3-include-html="partials/footer.html"></div>
+    <div w3-include-html="partials/hamburger-menu.html"></div>
+    <script>w3.includeHTML();</script>
+    <script type="text/javascript" src="js/hamburger-menu.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
Overrides default GitHub Pages 404 page now

See screenshot below: (note, the JS effects don't show because it was running from static file. The background is the video background, and this will just replace the blue header on the regular page)
![screen shot 2018-06-19 at 10 24 55 am](https://user-images.githubusercontent.com/14957047/41614216-b53b0672-73ac-11e8-8c2d-9b3df8b35325.png)
