### PR TITLE
To add Zetane in the visualize section in the supported tools page

### DIFF
--- a/supported-tools.html
+++ b/supported-tools.html
@@ -273,7 +273,8 @@
                                         <p>Better understand your model by visualizing its computational graph.</p>
                                         <div class="additional-tools-icons">
                                                 <a href="https://github.com/lutzroeder/Netron" target="_blank" class="mr-4"><img src="./images/logos/logo-netron.png" alt="Netron"></a>
-                                                <a href="https://github.com/PaddlePaddle/VisualDL" target="_blank"><img src="./images/logos/logo-VsualDL.png" alt="VisualDL"></a>
+                                                <a href="https://github.com/PaddlePaddle/VisualDL" target="_blank" class="mr-4"><img src="./images/logos/logo-VsualDL.png" alt="VisualDL"></a>
+                                                <a href="https://github.com/zetane/viewer" target="_blank"><img src="./images/logos/logo-zetane.png" alt="Zetane"></a>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
We added Zetane in the Visualize section in the supported-tools html page.