### PR TITLE
Fix broken Slack join URL

### DIFF
--- a/js/news.json
+++ b/js/news.json
@@ -127,7 +127,7 @@
             "newsShortTitle": "ONNX Slack Channel Opened",
             "newsDescription": "We are migrating to Slack from Gitter to encourage open discussion among the community. Please sign up at https://slack.lfai.foundation/ and join the ONNX Slack channel using the link.",
             "newsLinkText": "JOIN ONNX Slack Channel",
-            "newsLinkURL": "https://lfaifoundation.slack.com/archives/C016UBNDBL2",
+            "newsLinkURL": "https://join.slack.com/t/lfaifoundation/shared_invite/zt-o65errpw-gMTbwNr7FnNbVXNVFkmyNA",
             "newsDate": "Sep 18, 2020"
         },
         {


### PR DESCRIPTION
Same as https://github.com/onnx/onnx/pull/4108. Fix an issue reported by https://github.com/onnx/onnx/discussions/4197. I only fixed the link in news since it's an URL for joining. Not sure whether we should fix the Slack link in the top-right corner as well.