### PR TITLE
[WIP] add media section with p.ex. videos

### DIFF
--- a/media.html
+++ b/media.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>ONNX | Supported Tools</title>
+    <link rel="icon" href="./images/onnx-fevicon.png" type="image/gif" sizes="16x16">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:100,100i,300,300i,400,400i,700,700i,900,900i&display=swap">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="css/custom.css">
+    <link rel="stylesheet" href="css/responsive.css">
+</head>
+
+<body class="innerpage-main-wrapper">
+    <a class="skip-main" href="#skipMain">Skip to main content</a>
+    <!-- Partial header.html Start-->
+    <div w3-include-html="partials/navigation.html"></div>
+    <!-- Partial header.html End-->
+    <div class="main-wrapper">
+        <div class="top-banner-bg"></div>
+
+        <div id="skipMain" role="main" tabindex="-1">
+
+                <section class="blue-page-title-bar py-3 pb-3">
+                    <div class="outer-container mx-auto">
+                        <div class="container-fluid">
+                            <div class="row">
+                                <div class="col-12">
+                                    <h1 class="text-uppercase mb-0">Media</h1>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+                <div class="outer-container mx-auto py-4 py-md-5">
+
+
+                    <section class="blue-title-columns pb-4 pb-md-5">
+                        <div class="container-fluid">
+                            <div class="row">
+                                <div class="col-12 col-md-12">
+                                    <p class="subheading-4 bold-text mb-0">
+                                        In addition to the Community Day, which is usually held twice a year, Onnx is also becoming more widespread at various other conferences. 
+                                        To show the diversity of the application and how the community uses Onnx and what the topics are, below is an incomplete list of talks at various conferences (write an email or a pull request to add a talk)
+                                    </p>
+                                </div>
+
+                            </div>
+                        </div>
+                    </section>
+                    <hr class="border-top my-0 mx-15">
+                    <section class="py-4 py-md-5">
+                        <div class="container-fluid">
+                            <div class="row" id="buildModel">
+                                <div class="col-12 col-md-12 pl-90 mb-4">
+                                    <div class="icon-container icon-wrapper">
+                                        <img src="images/icon/icon-build-model-1.svg" alt="">
+                                    </div>
+                                    <h2 class="subheading-2 blue-text"> Videos</h2>
+                                </div>
+                                <div class="col-12 col-md-12">
+                                    <div class="border p-3 p-sm-4">
+                                        <h3 class="subheading-4 blue-text">ONNX Community Day</h3>
+                                        <p class="mb-4">Community contributions at the central community event. You can find slides, videos and experts there</p>
+                                        <div class="row supported-tools-logo icon-box text-center">
+                                            
+											
+											
+                                            <div class="col col-5-3 mb-5">
+                                                <a href="https://wiki.lfaidata.foundation/display/DL/ONNX+Community+Day+-+June+24" target="_blank">ONNX Community Meetup - June 2022 </a>
+                                            </div>
+                                            
+                                            <div class="col col-5-3 mb-5">
+                                                <a href="https://wiki.lfaidata.foundation/pages/viewpage.action?pageId=46989689" target="_blank">ONNX Community Virtual Meetup - October 2021 </a>
+                                            </div>
+											
+											<div class="col col-5-3 mb-5">
+                                                <a href="https://wiki.lfaidata.foundation/pages/viewpage.action?pageId=35160391" target="_blank">ONNX Community Virtual Meetup - March 2021 </a>
+                                            </div>
+											
+											
+											
+											<div class="col col-5-3 mb-5">
+                                                <a href="https://wiki.lfai.foundation/x/pgDQAQ" target="_blank">ONNX Community Virtual Meetup - October 2020 </a>
+                                            </div>
+											
+								
+                                        </div>
+										
+                                        <h3 class="subheading-4 blue-text">Conference Videos</h3>
+                                        <p class="mb-4">Incomplete list of Onnx at other conferences.</p>
+                                        <div class="row supported-tools-logo icon-box text-center">
+                                            
+                                            
+                                        </div>
+										
+										
+										
+
+                                        <table class="table">
+  <thead class="thead-light">
+    <tr>
+      <th scope="col">Index</th>
+      <th scope="col">Conference</th>
+      <th scope="col">Title</th>
+      <th scope="col">Media link</th>
+    </tr>
+  </thead>
+  <tbody>
+   <tr>
+      <th scope="row">1</th>
+      <td>PyConBerlin 2022</td>
+      <td>Making Machine Learning Applications Fast and Simple with Onnx</td>
+      <td><a href="https://www.youtube.com/watch?v=fucKKi2zMw4" target="_blank">https://www.youtube.com/watch?v=fucKKi2zMw4</a></td>
+    </tr>
+    <tr>
+      <th scope="row">2</th>
+      <td>tvmcon2021</td>
+      <td>ONNX, ONNX Runtime, and TVM</td>
+      <td><a href="https://www.tvmcon.org/events/onnx-onnx-runtime-and-tvm/" target="_blank">https://www.tvmcon.org/events/onnx-onnx-runtime-and-tvm/</a></td>
+    </tr>
+    <tr>
+      <th scope="row">3</th>
+      <td>PyData Global 2021</td>
+      <td>Accelerating ML Inference at Scale with ONNX, Triton and Seldo</td>
+      <td><a href="https://www.youtube.com/watch?v=Sv7rI-iFvXI" target="_blank">https://www.youtube.com/watch?v=Sv7rI-iFvXI</a></td>
+    </tr>
+   
+	
+	
+	
+	
+	
+	
+  </tbody>
+</table>
+
+                                    </div>
+                                </div>
+                            </div>
+
+                                                                    </div></section>
+                   
+                </div>
+
+            </div>
+            <!-- Partial footer.html Start-->
+            <div w3-include-html="partials/footer.html"></div>
+            <!-- Partial footer.html End-->
+            <a id="back-to-top" href="#" class="btn btn-lg back-to-top" role="button" aria-label="Back to top"><span
+                    class="fa fa-angle-up"></span></a>
+
+    </div>
+    <script src="https://www.w3schools.com/lib/w3.js"></script>
+    <script>w3.includeHTML();</script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+    <script src="./js/custom.js"></script>
+</body>
+
+</html>

--- a/media.html
+++ b/media.html
@@ -65,7 +65,7 @@
                                 <div class="col-12 col-md-12">
                                     <div class="border p-3 p-sm-4">
                                         <h3 class="subheading-4 blue-text">ONNX Community Day</h3>
-                                        <p class="mb-4">Community contributions at the central community event. You can find slides, videos and experts there</p>
+                                        <p class="mb-4">Community contributions at the central community event. (You can find slides, videos and experts there)</p>
                                         <div class="row supported-tools-logo icon-box text-center">
                                             
 											

--- a/partials/navigation.html
+++ b/partials/navigation.html
@@ -26,6 +26,9 @@
                         <li class="nav-item about">
                             <a class="nav-link pr-3" href="/about.html">ABOUT</a>
                         </li>
+						<li class="nav-item about">
+                            <a class="nav-link pr-3" href="/media.html">MEDIA</a>
+                        </li>
                         <li class="nav-item">
                             <a class="nav-link pr-3" href="/slack.html" target="_blank">SLACK</a>
                         </li>


### PR DESCRIPTION
I would find it very helpful to have a media section on the homepage.
With links to the Community Days and to other conference contributions.

Then I could imagine a link to Arxiv and google scholar to onnx articles.
Or only a selection of p.ex. 10 

Regarding videos I would find something like https://pyvideo.org/ exciting. I could imagine to contribute the corresponding json. But maybe hosting something like that is also a bit more work.

Signed-off-by: andife <fehlner@arcor.de>