### PR TITLE
Removed zoom meeting link

### DIFF
--- a/js/news.json
+++ b/js/news.json
@@ -94,7 +94,7 @@
             "newsId": "new60",
             "newsTitle": "Upcoming ONNX Roadmap discussions",
             "newsShortTitle": "Upcoming ONNX Roadmap discussions",
-            "newsDescription": "The upcoming ONNX Roadmap discussions will be on Sept 8th (5:30 PST), 17th (10am PST), 22nd (5:30 PST), and Oct 1st (10am PST). Each meeting will last 30 min and will cover 3 topics, which are listed in document linked to the READ MORE link below. Join the discussion to provide valuable feedback. https://zoom.us/j/784475658?pwd=czhtNllVMnFPQkhEUXFMWlZLT2l6dz09",
+            "newsDescription": "The upcoming ONNX Roadmap discussions will be on Sept 8th (5:30 PST), 17th (10am PST), 22nd (5:30 PST), and Oct 1st (10am PST). Each meeting will last 30 min and will cover 3 topics, which are listed in document linked to the READ MORE link below. Join the discussion to provide valuable feedback.",
             "newsLinkText": "READ MORE",
             "newsLinkURL": "https://onnx.ai/roadmap",
             "newsDate": "Sept 8, 2021"


### PR DESCRIPTION
Showed up in a sweep, link was not necessary.