### PR TITLE
change contributing link

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
                                         </a>
                                     </div>
                                     <div class="col-6 col-md-3">
-                                        <a href="https://github.com/onnx/onnx/blob/main/docs/CONTRIBUTING.md#development" target="_blank" class="card-4 community-card subheading-5 text-center px-3 py-3 text-white bold-text">
+                                        <a href="https://github.com/onnx/onnx/blob/main/CONTRIBUTING.md#development" target="_blank" class="card-4 community-card subheading-5 text-center px-3 py-3 text-white bold-text">
                                             Check out our contribution guide
                                         </a>
                                     </div>


### PR DESCRIPTION
https://github.com/onnx/onnx.github.io/issues/192

There is an issue with the 'check out our contribution guide' button link, which redirects to an outdated path, resulting in a 404 error. I have addressed this by making the necessary corrections and submitting a pull request.

`https://github.com/onnx/onnx/blob/main/docs/CONTRIBUTING.md#development`

<img width="1236" alt="Screenshot 2023-12-14 at 11 36 23 AM" src="https://github.com/onnx/onnx.github.io/assets/20737479/1959b972-33cd-4d52-ad00-f63ee86d336c">

`https://github.com/onnx/onnx/blob/main/CONTRIBUTING.md#development`

Your review would be greatly appreciated :)