### PR TITLE
Fix the broken link to CONTRIBUTING.md

### DIFF
--- a/about.html
+++ b/about.html
@@ -67,7 +67,7 @@
                                     <p>
                                         ONNX is a community project. We encourage you to join the effort and contribute feedback, ideas and code.
                                     </p>
-                                    <p>For more information, check out our <a href="https://github.com/onnx/onnx/blob/master/docs/CONTRIBUTING.md#development" target="_blank" class="link">contribution guide</a>, or join a <a target="_blank" href="https://github.com/onnx/onnx/blob/master/community/sigs.md#sigs---special-interest-groups" class="link">Special
+                                    <p>For more information, check out our <a href="https://github.com/onnx/onnx/blob/main/CONTRIBUTING.md#development" target="_blank" class="link">contribution guide</a>, or join a <a target="_blank" href="https://github.com/onnx/onnx/blob/master/community/sigs.md#sigs---special-interest-groups" class="link">Special
                                             Interest Group</a> (SIG) or <a href="https://github.com/onnx/onnx/blob/master/community/working-groups.md#working-groups" target="_blank" class="link">Working Group</a> today.</p>
                                 </div>
                             </div>


### PR DESCRIPTION
#192

This is similar to #193, which fixed the broken link in `index.html`, but this commit fixes the broken link in `about.html`.

As far as I checked by running `grep -r CONTRIBUTING.md`, no other codes need the same fix.