### PR TITLE
Fix outdated hyperlinks that refer the ONNX master branch

### DIFF
--- a/about.html
+++ b/about.html
@@ -67,8 +67,8 @@
                                     <p>
                                         ONNX is a community project. We encourage you to join the effort and contribute feedback, ideas and code.
                                     </p>
-                                    <p>For more information, check out our <a href="https://github.com/onnx/onnx/blob/main/CONTRIBUTING.md#development" target="_blank" class="link">contribution guide</a>, or join a <a target="_blank" href="https://github.com/onnx/onnx/blob/master/community/sigs.md#sigs---special-interest-groups" class="link">Special
-                                            Interest Group</a> (SIG) or <a href="https://github.com/onnx/onnx/blob/master/community/working-groups.md#working-groups" target="_blank" class="link">Working Group</a> today.</p>
+                                    <p>For more information, check out our <a href="https://github.com/onnx/onnx/blob/main/CONTRIBUTING.md#development" target="_blank" class="link">contribution guide</a>, or join a <a target="_blank" href="https://github.com/onnx/onnx/blob/main/community/sigs.md#sigs---special-interest-groups" class="link">Special
+                                            Interest Group</a> (SIG) or <a href="https://github.com/onnx/onnx/blob/main/community/working-groups.md#working-groups" target="_blank" class="link">Working Group</a> today.</p>
                                 </div>
                             </div>
 

--- a/js/news.json
+++ b/js/news.json
@@ -324,7 +324,7 @@
             "newsId": "news43",
             "newsTitle": "Expanded ONNX Steering Committee Announced!",
             "newsShortTitle": "ONNX Steering Committee Announced!",
-            "newsDescription": "The ONNX community continues to grow with more than 28 companies and dozen's of tools supporting the spec. With the project undergoing significant growth, we are excited to announce that the [governance structure](https://github.com/onnx/onnx/tree/master/community) is expanding to include additional steering committee members and new leaders for a number of special interest groups (SIGs).",
+            "newsDescription": "The ONNX community continues to grow with more than 28 companies and dozen's of tools supporting the spec. With the project undergoing significant growth, we are excited to announce that the [governance structure](https://github.com/onnx/onnx/tree/main/community) is expanding to include additional steering committee members and new leaders for a number of special interest groups (SIGs).",
             "newsLinkText": "READ MORE",
             "newsLinkURL": "https://github.com/onnx/onnx/wiki/Expanded-ONNX-Steering-Committee-Announced!",
             "newsDate": "May 23, 2019"


### PR DESCRIPTION
ONNX's default branch was changed from 'master' to 'main'.
This patch reflects the branch name change into hyperlinks on the official webpage.

I checked that all changed URLs are valid.